### PR TITLE
fix: don't delay update on dwm tag switch

### DIFF
--- a/rootclock.c
+++ b/rootclock.c
@@ -1,156 +1,199 @@
 /* rootclock - draw a centered time/date on each monitor's portion of the root window. */
 #define _POSIX_C_SOURCE 200809L
+#include <X11/Xft/Xft.h>
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
-#include <X11/Xft/Xft.h>
 #include <X11/extensions/Xinerama.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/select.h>
 #include <time.h>
 
 #include "config.h"
 
-static int
-xft_color_alloc(Display *dpy, int screen, const char *hex, XftColor *out)
-{
-	Visual   *visual   = DefaultVisual(dpy, screen);
-	Colormap  colormap = DefaultColormap(dpy, screen);
-	return XftColorAllocName(dpy, visual, colormap, hex, out);
+static int xft_color_alloc(Display *dpy, int screen, const char *hex,
+                           XftColor *out) {
+  Visual *visual = DefaultVisual(dpy, screen);
+  Colormap colormap = DefaultColormap(dpy, screen);
+  return XftColorAllocName(dpy, visual, colormap, hex, out);
 }
 
 /* Draw a filled rect + centered time (+ optional date) as one vertical block */
-static void
-draw_clock_block(Display *dpy, XftDraw *xft, GC gc, int screen,
-                 int rx, int ry, int rw, int rh,
-                 XftFont *tf, XftFont *df, int show_date_flag,
-                 XftColor *bgc, XftColor *tcol, XftColor *dcol,
-                 const char *tbuf, const char *dbuf,
-                 int block_yoff, int spacing)
-{
-	/* background */
-	XSetForeground(dpy, gc, bgc->pixel);
-	XFillRectangle(dpy, RootWindow(dpy, screen), gc, rx, ry, (unsigned)rw, (unsigned)rh);
+static void draw_clock_block(Display *dpy, XftDraw *xft, GC gc, int screen,
+                             int rx, int ry, int rw, int rh, XftFont *tf,
+                             XftFont *df, int show_date_flag, XftColor *bgc,
+                             XftColor *tcol, XftColor *dcol, const char *tbuf,
+                             const char *dbuf, int block_yoff, int spacing) {
+  /* background */
+  XSetForeground(dpy, gc, bgc->pixel);
+  XFillRectangle(dpy, RootWindow(dpy, screen), gc, rx, ry, (unsigned)rw,
+                 (unsigned)rh);
 
-	/* measure verticals */
-	const int time_h = tf->ascent + tf->descent;
-	const int date_h = (show_date_flag && df) ? (df->ascent + df->descent) : 0;
-	const int total_h = time_h + (show_date_flag ? (spacing + date_h) : 0);
+  /* measure verticals */
+  const int time_h = tf->ascent + tf->descent;
+  const int date_h = (show_date_flag && df) ? (df->ascent + df->descent) : 0;
+  const int total_h = time_h + (show_date_flag ? (spacing + date_h) : 0);
 
-	/* baseline for the time line */
-	int base_y = ry + (rh - total_h) / 2 + tf->ascent + block_yoff;
+  /* baseline for the time line */
+  int base_y = ry + (rh - total_h) / 2 + tf->ascent + block_yoff;
 
-	/* center time horizontally using advance width */
-	XGlyphInfo ext;
-	XftTextExtentsUtf8(dpy, tf, (const FcChar8*)tbuf, (int)strlen(tbuf), &ext);
-	int x = rx + (rw - (int)ext.xOff) / 2;
-	XftDrawStringUtf8(xft, tcol, tf, x, base_y, (const FcChar8*)tbuf, (int)strlen(tbuf));
+  /* center time horizontally using advance width */
+  XGlyphInfo ext;
+  XftTextExtentsUtf8(dpy, tf, (const FcChar8 *)tbuf, (int)strlen(tbuf), &ext);
+  int x = rx + (rw - (int)ext.xOff) / 2;
+  XftDrawStringUtf8(xft, tcol, tf, x, base_y, (const FcChar8 *)tbuf,
+                    (int)strlen(tbuf));
 
-	if (show_date_flag && df && dbuf && *dbuf) {
-		/* baseline for date: below time’s descent + spacing */
-		int date_y = base_y + tf->descent + spacing + df->ascent;
+  if (show_date_flag && df && dbuf && *dbuf) {
+    /* baseline for date: below time’s descent + spacing */
+    int date_y = base_y + tf->descent + spacing + df->ascent;
 
-		XGlyphInfo dext;
-		XftTextExtentsUtf8(dpy, df, (const FcChar8*)dbuf, (int)strlen(dbuf), &dext);
-		int dx = rx + (rw - (int)dext.xOff) / 2;
-		XftDrawStringUtf8(xft, dcol, df, dx, date_y, (const FcChar8*)dbuf, (int)strlen(dbuf));
-	}
+    XGlyphInfo dext;
+    XftTextExtentsUtf8(dpy, df, (const FcChar8 *)dbuf, (int)strlen(dbuf),
+                       &dext);
+    int dx = rx + (rw - (int)dext.xOff) / 2;
+    XftDrawStringUtf8(xft, dcol, df, dx, date_y, (const FcChar8 *)dbuf,
+                      (int)strlen(dbuf));
+  }
 }
 
-int
-main(void)
-{
-	setlocale(LC_ALL, "");
+static void render_all(Display *dpy, int screen, XftFont *tf, XftFont *df,
+                       int show_date_flag, XftColor *bgc, XftColor *tcol,
+                       XftColor *dcol, const char *time_fmt_s,
+                       const char *date_fmt_s, int block_y_off_s,
+                       int line_spacing_s) {
+  Window root = RootWindow(dpy, screen);
+  Visual *visual = DefaultVisual(dpy, screen);
+  Colormap colormap = DefaultColormap(dpy, screen);
 
-	Display *dpy = XOpenDisplay(NULL);
-	if (!dpy) { fputs("rootclock: cannot open display\n", stderr); return 1; }
-	int screen = DefaultScreen(dpy);
-	Window root = RootWindow(dpy, screen);
+  /* Compose time/date strings once per frame */
+  time_t now = time(NULL);
+  struct tm *tm_info = localtime(&now);
+  char tbuf[64], dbuf[128];
+  strftime(tbuf, sizeof tbuf, time_fmt_s, tm_info);
+  if (show_date_flag)
+    strftime(dbuf, sizeof dbuf, date_fmt_s, tm_info);
 
-	/* Fonts */
-	XftFont *tf = XftFontOpenName(dpy, screen, time_font);
-	XftFont *df = show_date ? XftFontOpenName(dpy, screen, date_font) : NULL;
-	if (!tf || (show_date && !df)) {
-		fputs("rootclock: failed to load fonts\n", stderr);
-		return 1;
-	}
+  XftDraw *xft = XftDrawCreate(dpy, root, visual, colormap);
+  if (!xft)
+    return;
+  GC gc = DefaultGC(dpy, screen);
 
-	/* Colors */
-	XftColor tcol, dcol, bgc;
-	if (!xft_color_alloc(dpy, screen, time_color, &tcol) ||
-	    (show_date && !xft_color_alloc(dpy, screen, date_color, &dcol)) ||
-	    !xft_color_alloc(dpy, screen, bg_color,   &bgc)) {
-		fputs("rootclock: failed to alloc colors\n", stderr);
-		return 1;
-	}
+  /* Query monitors */
+  XineramaScreenInfo *xi = NULL;
+  int nmon = 1;
+  if (XineramaIsActive(dpy)) {
+    int n;
+    xi = XineramaQueryScreens(dpy, &n);
+    if (xi && n > 0)
+      nmon = n;
+  }
 
-	Visual   *visual   = DefaultVisual(dpy, screen);
-	Colormap  colormap = DefaultColormap(dpy, screen);
+  if (xi) {
+    for (int i = 0; i < nmon; i++) {
+      int rx = xi[i].x_org, ry = xi[i].y_org, rw = xi[i].width,
+          rh = xi[i].height;
+      draw_clock_block(dpy, xft, gc, screen, rx, ry, rw, rh, tf, df,
+                       show_date_flag, bgc, tcol, dcol, tbuf,
+                       show_date_flag ? dbuf : NULL, block_y_off_s,
+                       line_spacing_s);
+    }
+  } else {
+    int rw = DisplayWidth(dpy, screen);
+    int rh = DisplayHeight(dpy, screen);
+    draw_clock_block(dpy, xft, gc, screen, 0, 0, rw, rh, tf, df, show_date_flag,
+                     bgc, tcol, dcol, tbuf, show_date_flag ? dbuf : NULL,
+                     block_y_off_s, line_spacing_s);
+  }
 
-	struct timespec ts = { .tv_sec = refresh_sec, .tv_nsec = 0 };
+  XFlush(dpy);
+  XftDrawDestroy(xft);
+  if (xi)
+    XFree(xi);
+}
 
-	for (;;) {
-		/* Query monitors */
-		XineramaScreenInfo *xi = NULL;
-		int nmon = 1;
-		if (XineramaIsActive(dpy)) {
-			int n;
-			xi = XineramaQueryScreens(dpy, &n);
-			if (xi && n > 0) nmon = n;
-		}
+int main(void) {
+  setlocale(LC_ALL, "");
 
-		/* Prepare draw context each tick (robust on resizes) */
-		XftDraw *xft = XftDrawCreate(dpy, root, visual, colormap);
-		if (!xft) break;
+  Display *dpy = XOpenDisplay(NULL);
+  if (!dpy) {
+    fputs("rootclock: cannot open display\n", stderr);
+    return 1;
+  }
+  int screen = DefaultScreen(dpy);
+  Window root = RootWindow(dpy, screen);
 
-		/* Compose time/date strings once per tick */
-		time_t now = time(NULL);
-		struct tm *tm_info = localtime(&now);
-		char tbuf[64], dbuf[128];
-		strftime(tbuf, sizeof tbuf, time_fmt, tm_info);
-		if (show_date) strftime(dbuf, sizeof dbuf, date_fmt, tm_info);
+  /* Select events (after screen/root are valid) */
+  XSelectInput(dpy, root, ExposureMask | StructureNotifyMask);
 
-		GC gc = DefaultGC(dpy, screen);
+  /* Fonts */
+  XftFont *tf = XftFontOpenName(dpy, screen, time_font);
+  XftFont *df = show_date ? XftFontOpenName(dpy, screen, date_font) : NULL;
+  if (!tf || (show_date && !df)) {
+    fputs("rootclock: failed to load fonts\n", stderr);
+    return 1;
+  }
 
-		if (xi) {
-			for (int i = 0; i < nmon; i++) {
-				int rx = xi[i].x_org, ry = xi[i].y_org, rw = xi[i].width, rh = xi[i].height;
-				draw_clock_block(
-					dpy, xft, gc, screen,
-					rx, ry, rw, rh,
-					tf, df, show_date,
-					&bgc, &tcol, &dcol,
-					tbuf, show_date ? dbuf : NULL,
-					block_y_off, line_spacing
-				);
-			}
-		} else {
-			int rw = DisplayWidth(dpy, screen);
-			int rh = DisplayHeight(dpy, screen);
-			draw_clock_block(
-				dpy, xft, gc, screen,
-				0, 0, rw, rh,
-				tf, df, show_date,
-				&bgc, &tcol, &dcol,
-				tbuf, show_date ? dbuf : NULL,
-				block_y_off, line_spacing
-			);
-		}
+  /* Colors */
+  XftColor tcol, dcol, bgc;
+  if (!xft_color_alloc(dpy, screen, time_color, &tcol) ||
+      (show_date && !xft_color_alloc(dpy, screen, date_color, &dcol)) ||
+      !xft_color_alloc(dpy, screen, bg_color, &bgc)) {
+    fputs("rootclock: failed to alloc colors\n", stderr);
+    return 1;
+  }
 
-		XFlush(dpy);
-		XftDrawDestroy(xft);
-		if (xi) XFree(xi);
+  /* Event + timer loop:
+     - redraw immediately on Expose/ConfigureNotify
+     - also tick every refresh_sec for time changes
+  */
+  int xfd = ConnectionNumber(dpy);
+  int need_redraw = 1; /* draw once at start */
+  while (1) {
+    /* Drain any pending events */
+    while (XPending(dpy)) {
+      XEvent ev;
+      XNextEvent(dpy, &ev);
+      switch (ev.type) {
+      case Expose:
+      case ConfigureNotify:
+        need_redraw = 1;
+        break;
+      default:
+        break;
+      }
+    }
 
-		nanosleep(&ts, NULL);
-	}
+    if (need_redraw) {
+      render_all(dpy, screen, tf, df, show_date, &bgc, &tcol, &dcol, time_fmt,
+                 date_fmt, block_y_off, line_spacing);
+      need_redraw = 0;
+    }
 
-	/* (Normally unreachable) */
-	XftColorFree(dpy, visual, colormap, &tcol);
-	if (show_date) XftColorFree(dpy, visual, colormap, &dcol);
-	XftColorFree(dpy, visual, colormap, &bgc);
-	XftFontClose(dpy, tf);
-	if (df) XftFontClose(dpy, df);
-	XCloseDisplay(dpy);
-	return 0;
+    /* Wait for either: next X event OR the next tick */
+    struct timeval tv = {.tv_sec = refresh_sec, .tv_usec = 0};
+    fd_set fds;
+    FD_ZERO(&fds);
+    FD_SET(xfd, &fds);
+    int r = select(xfd + 1, &fds, NULL, NULL, &tv);
+    if (r == 0) {
+      /* timer fired */
+      need_redraw = 1;
+    } /* if r > 0: events will be processed in the next loop */
+  }
+
+  /* Unreachable in normal use, kept for completeness */
+  Visual *visual = DefaultVisual(dpy, screen);
+  Colormap colormap = DefaultColormap(dpy, screen);
+  XftColorFree(dpy, visual, colormap, &tcol);
+  if (show_date)
+    XftColorFree(dpy, visual, colormap, &dcol);
+  XftColorFree(dpy, visual, colormap, &bgc);
+  XftFontClose(dpy, tf);
+  if (df)
+    XftFontClose(dpy, df);
+  XCloseDisplay(dpy);
+  return 0;
 }

--- a/rootclock.c
+++ b/rootclock.c
@@ -173,7 +173,9 @@ int main(void) {
     }
 
     /* Wait for either: next X event OR the next tick */
-    struct timeval tv = {.tv_sec = refresh_sec, .tv_usec = 0};
+    struct timeval tv;
+    tv.tv_sec = refresh_sec;
+    tv.tv_usec = 0;
     fd_set fds;
     FD_ZERO(&fds);
     FD_SET(xfd, &fds);


### PR DESCRIPTION
This pull request refactors and improves the main event loop and rendering logic in `rootclock.c` to make the code more robust and maintainable. The changes introduce a dedicated `render_all` function for drawing the clock on all monitors, replace the previous `nanosleep`-based loop with a proper event/timer loop using `select`, and clean up formatting and resource management.

**Event loop and rendering improvements:**

* Replaced the old `nanosleep`-based loop with an event-driven loop using `select`, allowing immediate redraws on X events (Expose/ConfigureNotify) and periodic updates based on the refresh interval.
* Added a new `render_all` function to handle drawing the clock on all monitors, consolidating rendering logic and improving code organization.

**Code cleanup and formatting:**

* Improved code formatting and indentation for readability, especially in function definitions and drawing routines. [[1]](diffhunk://#diff-0ee7a2bed0b5ef5221ce63c23afa184c6bbde87b0ab8e9e5904a4246c2b56e22R3-R32) [[2]](diffhunk://#diff-0ee7a2bed0b5ef5221ce63c23afa184c6bbde87b0ab8e9e5904a4246c2b56e22L48-R130)
* Moved Xft and system header includes to the top of the file for clarity and consistency.

**Resource management:**

* Ensured proper cleanup of Xft resources and fonts at program exit, even if normally unreachable.