### PR TITLE
fix: use drw for all font drawing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 include config.mk
 
-SRC = rootclock.c
+SRC = rootclock.c drw.c util.c
 OBJ = ${SRC:.c=.o}
 
 all: rootclock

--- a/config.def.h
+++ b/config.def.h
@@ -1,20 +1,28 @@
 /* Appearance */
-static const char *bg_color   = "#000000";
+static const char *bg_color = "#000000";
 
 /* Time (1st line) */
-static const char *time_font  = "Liberation Sans:style=Bold:size=120";
+static const char *time_fonts[] = {
+    "Inter:style=ExtraBold:size=120",
+    "Liberation Sans:style=Bold:size=120",
+    "Noto Sans Math:style=Regular:size=120", /* fallback for ratio symbol */
+};
 static const char *time_color = "#ffffff";
-static const char *time_fmt   = "%H:%M";
+static const char *time_fmt = "%-H\xe2\x88\xb6%M";
 
 /* Date (2nd line; set show_date=0 to disable) */
-static const int   show_date  = 1;
-static const char *date_font  = "Liberation Sans:style=Regular:size=26";
+static const int show_date = 1;
+static const char *date_fonts[] = {
+    "Inter:style=Regular:size=26",
+    "Liberation Sans:style=Regular:size=26",
+    "Noto Sans:style=Regular:size=26",
+};
 static const char *date_color = "#333333";
-static const char *date_fmt   = "%A, %-d %B %Y";
+static const char *date_fmt = "%A, %-d %B %Y";
 
 /* Refresh interval (seconds) */
-static const int   refresh_sec = 1;
+static const int refresh_sec = 1;
 
 /* Vertical layout */
-static const int   block_y_off  = 0;   /* shift entire block (time+date) in px */
-static const int   line_spacing = 12;  /* gap between time and date in px */
+static const int block_y_off = 0;   /* shift entire block (time+date) in px */
+static const int line_spacing = 12; /* gap between time and date in px */

--- a/drw.c
+++ b/drw.c
@@ -1,0 +1,448 @@
+/* See LICENSE file for copyright and license details. */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <X11/Xlib.h>
+#include <X11/Xft/Xft.h>
+
+#include "drw.h"
+#include "util.h"
+
+#define UTF_INVALID 0xFFFD
+
+static int
+utf8decode(const char *s_in, long *u, int *err)
+{
+	static const unsigned char lens[] = {
+		/* 0XXXX */ 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+		/* 10XXX */ 0, 0, 0, 0, 0, 0, 0, 0,  /* invalid */
+		/* 110XX */ 2, 2, 2, 2,
+		/* 1110X */ 3, 3,
+		/* 11110 */ 4,
+		/* 11111 */ 0,  /* invalid */
+	};
+	static const unsigned char leading_mask[] = { 0x7F, 0x1F, 0x0F, 0x07 };
+	static const unsigned int overlong[] = { 0x0, 0x80, 0x0800, 0x10000 };
+
+	const unsigned char *s = (const unsigned char *)s_in;
+	int len = lens[*s >> 3];
+	*u = UTF_INVALID;
+	*err = 1;
+	if (len == 0)
+		return 1;
+
+	long cp = s[0] & leading_mask[len - 1];
+	for (int i = 1; i < len; ++i) {
+		if (s[i] == '\0' || (s[i] & 0xC0) != 0x80)
+			return i;
+		cp = (cp << 6) | (s[i] & 0x3F);
+	}
+	/* out of range, surrogate, overlong encoding */
+	if (cp > 0x10FFFF || (cp >> 11) == 0x1B || cp < overlong[len - 1])
+		return len;
+
+	*err = 0;
+	*u = cp;
+	return len;
+}
+
+Drw *
+drw_create(Display *dpy, int screen, Window root, unsigned int w, unsigned int h)
+{
+	Drw *drw = ecalloc(1, sizeof(Drw));
+
+	drw->dpy = dpy;
+	drw->screen = screen;
+	drw->root = root;
+	drw->w = w;
+	drw->h = h;
+	drw->drawable = XCreatePixmap(dpy, root, w, h, DefaultDepth(dpy, screen));
+	drw->gc = XCreateGC(dpy, root, 0, NULL);
+	XSetLineAttributes(dpy, drw->gc, 1, LineSolid, CapButt, JoinMiter);
+
+	return drw;
+}
+
+void
+drw_resize(Drw *drw, unsigned int w, unsigned int h)
+{
+	if (!drw)
+		return;
+
+	drw->w = w;
+	drw->h = h;
+	if (drw->drawable)
+		XFreePixmap(drw->dpy, drw->drawable);
+	drw->drawable = XCreatePixmap(drw->dpy, drw->root, w, h, DefaultDepth(drw->dpy, drw->screen));
+}
+
+void
+drw_free(Drw *drw)
+{
+	XFreePixmap(drw->dpy, drw->drawable);
+	XFreeGC(drw->dpy, drw->gc);
+	drw_fontset_free(drw->fonts);
+	free(drw);
+}
+
+/* This function is an implementation detail. Library users should use
+ * drw_fontset_create instead.
+ */
+static Fnt *
+xfont_create(Drw *drw, const char *fontname, FcPattern *fontpattern)
+{
+	Fnt *font;
+	XftFont *xfont = NULL;
+	FcPattern *pattern = NULL;
+
+	if (fontname) {
+		/* Using the pattern found at font->xfont->pattern does not yield the
+		 * same substitution results as using the pattern returned by
+		 * FcNameParse; using the latter results in the desired fallback
+		 * behaviour whereas the former just results in missing-character
+		 * rectangles being drawn, at least with some fonts. */
+		if (!(xfont = XftFontOpenName(drw->dpy, drw->screen, fontname))) {
+			fprintf(stderr, "error, cannot load font from name: '%s'\n", fontname);
+			return NULL;
+		}
+		if (!(pattern = FcNameParse((FcChar8 *) fontname))) {
+			fprintf(stderr, "error, cannot parse font name to pattern: '%s'\n", fontname);
+			XftFontClose(drw->dpy, xfont);
+			return NULL;
+		}
+	} else if (fontpattern) {
+		if (!(xfont = XftFontOpenPattern(drw->dpy, fontpattern))) {
+			fprintf(stderr, "error, cannot load font from pattern.\n");
+			return NULL;
+		}
+	} else {
+		die("no font specified.");
+	}
+
+	font = ecalloc(1, sizeof(Fnt));
+	font->xfont = xfont;
+	font->pattern = pattern;
+	font->h = xfont->ascent + xfont->descent;
+	font->dpy = drw->dpy;
+
+	return font;
+}
+
+static void
+xfont_free(Fnt *font)
+{
+	if (!font)
+		return;
+	if (font->pattern)
+		FcPatternDestroy(font->pattern);
+	XftFontClose(font->dpy, font->xfont);
+	free(font);
+}
+
+Fnt*
+drw_fontset_create(Drw* drw, const char *fonts[], size_t fontcount)
+{
+	Fnt *cur, *ret = NULL;
+	size_t i;
+
+	if (!drw || !fonts)
+		return NULL;
+
+	for (i = 1; i <= fontcount; i++) {
+		if ((cur = xfont_create(drw, fonts[fontcount - i], NULL))) {
+			cur->next = ret;
+			ret = cur;
+		}
+	}
+	return (drw->fonts = ret);
+}
+
+void
+drw_fontset_free(Fnt *font)
+{
+	if (font) {
+		drw_fontset_free(font->next);
+		xfont_free(font);
+	}
+}
+
+void
+drw_clr_create(Drw *drw, Clr *dest, const char *clrname)
+{
+	if (!drw || !dest || !clrname)
+		return;
+
+	if (!XftColorAllocName(drw->dpy, DefaultVisual(drw->dpy, drw->screen),
+	                       DefaultColormap(drw->dpy, drw->screen),
+	                       clrname, dest))
+		die("error, cannot allocate color '%s'", clrname);
+}
+
+/* Wrapper to create color schemes. The caller has to call free(3) on the
+ * returned color scheme when done using it. */
+Clr *
+drw_scm_create(Drw *drw, const char *clrnames[], size_t clrcount)
+{
+	size_t i;
+	Clr *ret;
+
+	/* need at least two colors for a scheme */
+	if (!drw || !clrnames || clrcount < 2 || !(ret = ecalloc(clrcount, sizeof(XftColor))))
+		return NULL;
+
+	for (i = 0; i < clrcount; i++)
+		drw_clr_create(drw, &ret[i], clrnames[i]);
+	return ret;
+}
+
+void
+drw_setfontset(Drw *drw, Fnt *set)
+{
+	if (drw)
+		drw->fonts = set;
+}
+
+void
+drw_setscheme(Drw *drw, Clr *scm)
+{
+	if (drw)
+		drw->scheme = scm;
+}
+
+void
+drw_rect(Drw *drw, int x, int y, unsigned int w, unsigned int h, int filled, int invert)
+{
+	if (!drw || !drw->scheme)
+		return;
+	XSetForeground(drw->dpy, drw->gc, invert ? drw->scheme[ColBg].pixel : drw->scheme[ColFg].pixel);
+	if (filled)
+		XFillRectangle(drw->dpy, drw->drawable, drw->gc, x, y, w, h);
+	else
+		XDrawRectangle(drw->dpy, drw->drawable, drw->gc, x, y, w - 1, h - 1);
+}
+
+int
+drw_text(Drw *drw, int x, int y, unsigned int w, unsigned int h, unsigned int lpad, const char *text, int invert)
+{
+	int ty, ellipsis_x = 0;
+	unsigned int tmpw, ew, ellipsis_w = 0, ellipsis_len, hash, h0, h1;
+	XftDraw *d = NULL;
+	Fnt *usedfont, *curfont, *nextfont;
+	int utf8strlen, utf8charlen, utf8err, render = x || y || w || h;
+	long utf8codepoint = 0;
+	const char *utf8str;
+	FcCharSet *fccharset;
+	FcPattern *fcpattern;
+	FcPattern *match;
+	XftResult result;
+	int charexists = 0, overflow = 0;
+	/* keep track of a couple codepoints for which we have no match. */
+	static unsigned int nomatches[128], ellipsis_width, invalid_width;
+	static const char invalid[] = "�";
+
+	if (!drw || (render && (!drw->scheme || !w)) || !text || !drw->fonts)
+		return 0;
+
+	if (!render) {
+		w = invert ? invert : ~invert;
+	} else {
+		XSetForeground(drw->dpy, drw->gc, drw->scheme[invert ? ColFg : ColBg].pixel);
+		XFillRectangle(drw->dpy, drw->drawable, drw->gc, x, y, w, h);
+		if (w < lpad)
+			return x + w;
+		d = XftDrawCreate(drw->dpy, drw->drawable,
+		                  DefaultVisual(drw->dpy, drw->screen),
+		                  DefaultColormap(drw->dpy, drw->screen));
+		x += lpad;
+		w -= lpad;
+	}
+
+	usedfont = drw->fonts;
+	if (!ellipsis_width && render)
+		ellipsis_width = drw_fontset_getwidth(drw, "...");
+	if (!invalid_width && render)
+		invalid_width = drw_fontset_getwidth(drw, invalid);
+	while (1) {
+		ew = ellipsis_len = utf8err = utf8charlen = utf8strlen = 0;
+		utf8str = text;
+		nextfont = NULL;
+		while (*text) {
+			utf8charlen = utf8decode(text, &utf8codepoint, &utf8err);
+			for (curfont = drw->fonts; curfont; curfont = curfont->next) {
+				charexists = charexists || XftCharExists(drw->dpy, curfont->xfont, utf8codepoint);
+				if (charexists) {
+					drw_font_getexts(curfont, text, utf8charlen, &tmpw, NULL);
+					if (ew + ellipsis_width <= w) {
+						/* keep track where the ellipsis still fits */
+						ellipsis_x = x + ew;
+						ellipsis_w = w - ew;
+						ellipsis_len = utf8strlen;
+					}
+
+					if (ew + tmpw > w) {
+						overflow = 1;
+						/* called from drw_fontset_getwidth_clamp():
+						 * it wants the width AFTER the overflow
+						 */
+						if (!render)
+							x += tmpw;
+						else
+							utf8strlen = ellipsis_len;
+					} else if (curfont == usedfont) {
+						text += utf8charlen;
+						utf8strlen += utf8err ? 0 : utf8charlen;
+						ew += utf8err ? 0 : tmpw;
+					} else {
+						nextfont = curfont;
+					}
+					break;
+				}
+			}
+
+			if (overflow || !charexists || nextfont || utf8err)
+				break;
+			else
+				charexists = 0;
+		}
+
+		if (utf8strlen) {
+			if (render) {
+				ty = y + (h - usedfont->h) / 2 + usedfont->xfont->ascent;
+				XftDrawStringUtf8(d, &drw->scheme[invert ? ColBg : ColFg],
+				                  usedfont->xfont, x, ty, (XftChar8 *)utf8str, utf8strlen);
+			}
+			x += ew;
+			w -= ew;
+		}
+		if (utf8err && (!render || invalid_width < w)) {
+			if (render)
+				drw_text(drw, x, y, w, h, 0, invalid, invert);
+			x += invalid_width;
+			w -= invalid_width;
+		}
+		if (render && overflow)
+			drw_text(drw, ellipsis_x, y, ellipsis_w, h, 0, "...", invert);
+
+		if (!*text || overflow) {
+			break;
+		} else if (nextfont) {
+			charexists = 0;
+			usedfont = nextfont;
+		} else {
+			/* Regardless of whether or not a fallback font is found, the
+			 * character must be drawn. */
+			charexists = 1;
+
+			hash = (unsigned int)utf8codepoint;
+			hash = ((hash >> 16) ^ hash) * 0x21F0AAAD;
+			hash = ((hash >> 15) ^ hash) * 0xD35A2D97;
+			h0 = ((hash >> 15) ^ hash) % LENGTH(nomatches);
+			h1 = (hash >> 17) % LENGTH(nomatches);
+			/* avoid expensive XftFontMatch call when we know we won't find a match */
+			if (nomatches[h0] == utf8codepoint || nomatches[h1] == utf8codepoint)
+				goto no_match;
+
+			fccharset = FcCharSetCreate();
+			FcCharSetAddChar(fccharset, utf8codepoint);
+
+			if (!drw->fonts->pattern) {
+				/* Refer to the comment in xfont_create for more information. */
+				die("the first font in the cache must be loaded from a font string.");
+			}
+
+			fcpattern = FcPatternDuplicate(drw->fonts->pattern);
+			FcPatternAddCharSet(fcpattern, FC_CHARSET, fccharset);
+			FcPatternAddBool(fcpattern, FC_SCALABLE, FcTrue);
+
+			FcConfigSubstitute(NULL, fcpattern, FcMatchPattern);
+			FcDefaultSubstitute(fcpattern);
+			match = XftFontMatch(drw->dpy, drw->screen, fcpattern, &result);
+
+			FcCharSetDestroy(fccharset);
+			FcPatternDestroy(fcpattern);
+
+			if (match) {
+				usedfont = xfont_create(drw, NULL, match);
+				if (usedfont && XftCharExists(drw->dpy, usedfont->xfont, utf8codepoint)) {
+					for (curfont = drw->fonts; curfont->next; curfont = curfont->next)
+						; /* NOP */
+					curfont->next = usedfont;
+				} else {
+					xfont_free(usedfont);
+					nomatches[nomatches[h0] ? h1 : h0] = utf8codepoint;
+no_match:
+					usedfont = drw->fonts;
+				}
+			}
+		}
+	}
+	if (d)
+		XftDrawDestroy(d);
+
+	return x + (render ? w : 0);
+}
+
+void
+drw_map(Drw *drw, Window win, int x, int y, unsigned int w, unsigned int h)
+{
+	if (!drw)
+		return;
+
+	XCopyArea(drw->dpy, drw->drawable, win, drw->gc, x, y, w, h, x, y);
+	XSync(drw->dpy, False);
+}
+
+unsigned int
+drw_fontset_getwidth(Drw *drw, const char *text)
+{
+	if (!drw || !drw->fonts || !text)
+		return 0;
+	return drw_text(drw, 0, 0, 0, 0, 0, text, 0);
+}
+
+unsigned int
+drw_fontset_getwidth_clamp(Drw *drw, const char *text, unsigned int n)
+{
+	unsigned int tmp = 0;
+	if (drw && drw->fonts && text && n)
+		tmp = drw_text(drw, 0, 0, 0, 0, 0, text, n);
+	return MIN(n, tmp);
+}
+
+void
+drw_font_getexts(Fnt *font, const char *text, unsigned int len, unsigned int *w, unsigned int *h)
+{
+	XGlyphInfo ext;
+
+	if (!font || !text)
+		return;
+
+	XftTextExtentsUtf8(font->dpy, font->xfont, (XftChar8 *)text, len, &ext);
+	if (w)
+		*w = ext.xOff;
+	if (h)
+		*h = font->h;
+}
+
+Cur *
+drw_cur_create(Drw *drw, int shape)
+{
+	Cur *cur;
+
+	if (!drw || !(cur = ecalloc(1, sizeof(Cur))))
+		return NULL;
+
+	cur->cursor = XCreateFontCursor(drw->dpy, shape);
+
+	return cur;
+}
+
+void
+drw_cur_free(Drw *drw, Cur *cursor)
+{
+	if (!cursor)
+		return;
+
+	XFreeCursor(drw->dpy, cursor->cursor);
+	free(cursor);
+}

--- a/drw.h
+++ b/drw.h
@@ -1,0 +1,58 @@
+/* See LICENSE file for copyright and license details. */
+
+typedef struct {
+	Cursor cursor;
+} Cur;
+
+typedef struct Fnt {
+	Display *dpy;
+	unsigned int h;
+	XftFont *xfont;
+	FcPattern *pattern;
+	struct Fnt *next;
+} Fnt;
+
+enum { ColFg, ColBg, ColBorder }; /* Clr scheme index */
+typedef XftColor Clr;
+
+typedef struct {
+	unsigned int w, h;
+	Display *dpy;
+	int screen;
+	Window root;
+	Drawable drawable;
+	GC gc;
+	Clr *scheme;
+	Fnt *fonts;
+} Drw;
+
+/* Drawable abstraction */
+Drw *drw_create(Display *dpy, int screen, Window win, unsigned int w, unsigned int h);
+void drw_resize(Drw *drw, unsigned int w, unsigned int h);
+void drw_free(Drw *drw);
+
+/* Fnt abstraction */
+Fnt *drw_fontset_create(Drw* drw, const char *fonts[], size_t fontcount);
+void drw_fontset_free(Fnt* set);
+unsigned int drw_fontset_getwidth(Drw *drw, const char *text);
+unsigned int drw_fontset_getwidth_clamp(Drw *drw, const char *text, unsigned int n);
+void drw_font_getexts(Fnt *font, const char *text, unsigned int len, unsigned int *w, unsigned int *h);
+
+/* Colorscheme abstraction */
+void drw_clr_create(Drw *drw, Clr *dest, const char *clrname);
+Clr *drw_scm_create(Drw *drw, const char *clrnames[], size_t clrcount);
+
+/* Cursor abstraction */
+Cur *drw_cur_create(Drw *drw, int shape);
+void drw_cur_free(Drw *drw, Cur *cursor);
+
+/* Drawing context manipulation */
+void drw_setfontset(Drw *drw, Fnt *set);
+void drw_setscheme(Drw *drw, Clr *scm);
+
+/* Drawing functions */
+void drw_rect(Drw *drw, int x, int y, unsigned int w, unsigned int h, int filled, int invert);
+int drw_text(Drw *drw, int x, int y, unsigned int w, unsigned int h, unsigned int lpad, const char *text, int invert);
+
+/* Map functions */
+void drw_map(Drw *drw, Window win, int x, int y, unsigned int w, unsigned int h);

--- a/rootclock.c
+++ b/rootclock.c
@@ -4,6 +4,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/Xinerama.h>
+#include <fontconfig/fontconfig.h>
 #include <locale.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -12,63 +13,59 @@
 #include <time.h>
 
 #include "config.h"
+#include "drw.h"
+#include "util.h"
 
-static int xft_color_alloc(Display *dpy, int screen, const char *hex,
-                           XftColor *out) {
-  Visual *visual = DefaultVisual(dpy, screen);
-  Colormap colormap = DefaultColormap(dpy, screen);
-  return XftColorAllocName(dpy, visual, colormap, hex, out);
-}
+static void draw_block_for_region(Drw *drw, int rx, int ry, int rw, int rh,
+                                  Fnt *tf, Fnt *df, int show_date_flag,
+                                  Clr *bg_scm, Clr *time_scm, Clr *date_scm,
+                                  const char *tstr, const char *dstr,
+                                  int block_yoff, int spacing) {
+  /* fill background */
+  drw_setscheme(drw, bg_scm);
+  drw_rect(drw, rx, ry, rw, rh, 1, 0);
 
-/* Draw a filled rect + centered time (+ optional date) as one vertical block */
-static void draw_clock_block(Display *dpy, XftDraw *xft, GC gc, int screen,
-                             int rx, int ry, int rw, int rh, XftFont *tf,
-                             XftFont *df, int show_date_flag, XftColor *bgc,
-                             XftColor *tcol, XftColor *dcol, const char *tbuf,
-                             const char *dbuf, int block_yoff, int spacing) {
-  /* background */
-  XSetForeground(dpy, gc, bgc->pixel);
-  XFillRectangle(dpy, RootWindow(dpy, screen), gc, rx, ry, (unsigned)rw,
-                 (unsigned)rh);
+  /* metrics */
+  int time_h = tf->h;
+  int ascent_t = tf->xfont->ascent;
 
-  /* measure verticals */
-  const int time_h = tf->ascent + tf->descent;
-  const int date_h = (show_date_flag && df) ? (df->ascent + df->descent) : 0;
-  const int total_h = time_h + (show_date_flag ? (spacing + date_h) : 0);
-
-  /* baseline for the time line */
-  int base_y = ry + (rh - total_h) / 2 + tf->ascent + block_yoff;
-
-  /* center time horizontally using advance width */
-  XGlyphInfo ext;
-  XftTextExtentsUtf8(dpy, tf, (const FcChar8 *)tbuf, (int)strlen(tbuf), &ext);
-  int x = rx + (rw - (int)ext.xOff) / 2;
-  XftDrawStringUtf8(xft, tcol, tf, x, base_y, (const FcChar8 *)tbuf,
-                    (int)strlen(tbuf));
-
-  if (show_date_flag && df && dbuf && *dbuf) {
-    /* baseline for date: below time’s descent + spacing */
-    int date_y = base_y + tf->descent + spacing + df->ascent;
-
-    XGlyphInfo dext;
-    XftTextExtentsUtf8(dpy, df, (const FcChar8 *)dbuf, (int)strlen(dbuf),
-                       &dext);
-    int dx = rx + (rw - (int)dext.xOff) / 2;
-    XftDrawStringUtf8(xft, dcol, df, dx, date_y, (const FcChar8 *)dbuf,
-                      (int)strlen(dbuf));
+  int date_h = 0;
+  if (show_date_flag && df) {
+    date_h = df->h;
   }
+
+  int total_h = time_h + (show_date_flag ? (spacing + date_h) : 0);
+  int base_y = ry + (rh - total_h) / 2 + ascent_t + block_yoff;
+
+  /* time width + centered x */
+  drw_setfontset(drw, tf);
+  unsigned int tw = drw_fontset_getwidth(drw, tstr);
+  int tx = rx + (rw - (int)tw) / 2;
+
+  /* drw_text y is the top of the text box; it centers within h.
+     To place baseline at base_y, give box height = time_h and y = base_y -
+     ascent_t */
+  drw_setscheme(drw, time_scm);
+  drw_text(drw, tx, base_y - ascent_t, tw, time_h, 0, tstr, 0);
+
+  if (show_date_flag && df && dstr && *dstr) {
+    drw_setfontset(drw, df);
+    unsigned int dw = drw_fontset_getwidth(drw, dstr);
+    int dx = rx + (rw - (int)dw) / 2;
+    int date_top = base_y + (tf->h - ascent_t) + spacing; /* baseline gap */
+    int dy = date_top;
+    drw_setscheme(drw, date_scm);
+    drw_text(drw, dx, dy, dw, date_h, 0, dstr, 0);
+  }
+
+  /* copy this region to root */
+  drw_map(drw, drw->root, rx, ry, rw, rh);
 }
 
-static void render_all(Display *dpy, int screen, XftFont *tf, XftFont *df,
-                       int show_date_flag, XftColor *bgc, XftColor *tcol,
-                       XftColor *dcol, const char *time_fmt_s,
-                       const char *date_fmt_s, int block_y_off_s,
-                       int line_spacing_s) {
-  Window root = RootWindow(dpy, screen);
-  Visual *visual = DefaultVisual(dpy, screen);
-  Colormap colormap = DefaultColormap(dpy, screen);
-
-  /* Compose time/date strings once per frame */
+static void render_all(Drw *drw, Fnt *tf, Fnt *df, int show_date_flag,
+                       Clr *bg_scm, Clr *time_scm, Clr *date_scm,
+                       const char *time_fmt_s, const char *date_fmt_s,
+                       int block_y_off_s, int line_spacing_s) {
   time_t now = time(NULL);
   struct tm *tm_info = localtime(&now);
   char tbuf[64], dbuf[128];
@@ -76,17 +73,12 @@ static void render_all(Display *dpy, int screen, XftFont *tf, XftFont *df,
   if (show_date_flag)
     strftime(dbuf, sizeof dbuf, date_fmt_s, tm_info);
 
-  XftDraw *xft = XftDrawCreate(dpy, root, visual, colormap);
-  if (!xft)
-    return;
-  GC gc = DefaultGC(dpy, screen);
-
-  /* Query monitors */
+  /* monitors */
   XineramaScreenInfo *xi = NULL;
   int nmon = 1;
-  if (XineramaIsActive(dpy)) {
+  if (XineramaIsActive(drw->dpy)) {
     int n;
-    xi = XineramaQueryScreens(dpy, &n);
+    xi = XineramaQueryScreens(drw->dpy, &n);
     if (xi && n > 0)
       nmon = n;
   }
@@ -95,23 +87,19 @@ static void render_all(Display *dpy, int screen, XftFont *tf, XftFont *df,
     for (int i = 0; i < nmon; i++) {
       int rx = xi[i].x_org, ry = xi[i].y_org, rw = xi[i].width,
           rh = xi[i].height;
-      draw_clock_block(dpy, xft, gc, screen, rx, ry, rw, rh, tf, df,
-                       show_date_flag, bgc, tcol, dcol, tbuf,
-                       show_date_flag ? dbuf : NULL, block_y_off_s,
-                       line_spacing_s);
+      draw_block_for_region(drw, rx, ry, rw, rh, tf, df, show_date_flag, bg_scm,
+                            time_scm, date_scm, tbuf,
+                            show_date_flag ? dbuf : NULL, block_y_off_s,
+                            line_spacing_s);
     }
-  } else {
-    int rw = DisplayWidth(dpy, screen);
-    int rh = DisplayHeight(dpy, screen);
-    draw_clock_block(dpy, xft, gc, screen, 0, 0, rw, rh, tf, df, show_date_flag,
-                     bgc, tcol, dcol, tbuf, show_date_flag ? dbuf : NULL,
-                     block_y_off_s, line_spacing_s);
-  }
-
-  XFlush(dpy);
-  XftDrawDestroy(xft);
-  if (xi)
     XFree(xi);
+  } else {
+    int rw = DisplayWidth(drw->dpy, drw->screen);
+    int rh = DisplayHeight(drw->dpy, drw->screen);
+    draw_block_for_region(
+        drw, 0, 0, rw, rh, tf, df, show_date_flag, bg_scm, time_scm, date_scm,
+        tbuf, show_date_flag ? dbuf : NULL, block_y_off_s, line_spacing_s);
+  }
 }
 
 int main(void) {
@@ -125,77 +113,78 @@ int main(void) {
   int screen = DefaultScreen(dpy);
   Window root = RootWindow(dpy, screen);
 
-  /* Select events (after screen/root are valid) */
+  /* drw + initial size */
+  unsigned int rw = DisplayWidth(dpy, screen);
+  unsigned int rh = DisplayHeight(dpy, screen);
+  Drw *drw = drw_create(dpy, screen, root, rw, rh);
+  if (!drw)
+    return 1;
+
+  /* fonts */
+  Fnt *tf = drw_fontset_create(drw, time_fonts, LENGTH(time_fonts));
+  Fnt *df = show_date ? drw_fontset_create(drw, date_fonts, LENGTH(date_fonts))
+                      : NULL;
+  if (!tf || (show_date && !df))
+    die("rootclock: failed to load fonts");
+
+  /* color schemes:
+     index order: ColFg, ColBg, ColBorder
+     We'll use:
+       - bg_scm: fg=bg_color to fill background rectangles
+       - time_scm: fg=time_color, bg=bg_color
+       - date_scm: fg=date_color, bg=bg_color
+  */
+  const char *bg_names[] = {bg_color, bg_color, bg_color};
+  const char *time_names[] = {time_color, bg_color, bg_color};
+  const char *date_names[] = {date_color, bg_color, bg_color};
+  Clr *bg_scm = drw_scm_create(drw, bg_names, 3);
+  Clr *time_scm = drw_scm_create(drw, time_names, 3);
+  Clr *date_scm = drw_scm_create(drw, date_names, 3);
+  if (!bg_scm || !time_scm || !date_scm)
+    die("rootclock: color alloc failed");
+
+  /* events */
   XSelectInput(dpy, root, ExposureMask | StructureNotifyMask);
 
-  /* Fonts */
-  XftFont *tf = XftFontOpenName(dpy, screen, time_font);
-  XftFont *df = show_date ? XftFontOpenName(dpy, screen, date_font) : NULL;
-  if (!tf || (show_date && !df)) {
-    fputs("rootclock: failed to load fonts\n", stderr);
-    return 1;
-  }
-
-  /* Colors */
-  XftColor tcol, dcol, bgc;
-  if (!xft_color_alloc(dpy, screen, time_color, &tcol) ||
-      (show_date && !xft_color_alloc(dpy, screen, date_color, &dcol)) ||
-      !xft_color_alloc(dpy, screen, bg_color, &bgc)) {
-    fputs("rootclock: failed to alloc colors\n", stderr);
-    return 1;
-  }
-
-  /* Event + timer loop:
-     - redraw immediately on Expose/ConfigureNotify
-     - also tick every refresh_sec for time changes
-  */
+  /* loop: redraw on expose/resize and on timer ticks */
   int xfd = ConnectionNumber(dpy);
-  int need_redraw = 1; /* draw once at start */
-  while (1) {
-    /* Drain any pending events */
+  int need_redraw = 1;
+  for (;;) {
     while (XPending(dpy)) {
       XEvent ev;
       XNextEvent(dpy, &ev);
       switch (ev.type) {
       case Expose:
-      case ConfigureNotify:
         need_redraw = 1;
         break;
+      case ConfigureNotify: {
+        /* root size changed */
+        unsigned int nrw = DisplayWidth(dpy, screen);
+        unsigned int nrh = DisplayHeight(dpy, screen);
+        if (nrw != drw->w || nrh != drw->h)
+          drw_resize(drw, nrw, nrh);
+        need_redraw = 1;
+      } break;
       default:
         break;
       }
     }
 
     if (need_redraw) {
-      render_all(dpy, screen, tf, df, show_date, &bgc, &tcol, &dcol, time_fmt,
+      render_all(drw, tf, df, show_date, bg_scm, time_scm, date_scm, time_fmt,
                  date_fmt, block_y_off, line_spacing);
       need_redraw = 0;
     }
 
-    /* Wait for either: next X event OR the next tick */
-    struct timeval tv;
-    tv.tv_sec = refresh_sec;
-    tv.tv_usec = 0;
+    struct timeval tv = {.tv_sec = refresh_sec, .tv_usec = 0};
     fd_set fds;
     FD_ZERO(&fds);
     FD_SET(xfd, &fds);
     int r = select(xfd + 1, &fds, NULL, NULL, &tv);
-    if (r == 0) {
-      /* timer fired */
-      need_redraw = 1;
-    } /* if r > 0: events will be processed in the next loop */
+    if (r == 0)
+      need_redraw = 1; /* tick */
   }
 
-  /* Unreachable in normal use, kept for completeness */
-  Visual *visual = DefaultVisual(dpy, screen);
-  Colormap colormap = DefaultColormap(dpy, screen);
-  XftColorFree(dpy, visual, colormap, &tcol);
-  if (show_date)
-    XftColorFree(dpy, visual, colormap, &dcol);
-  XftColorFree(dpy, visual, colormap, &bgc);
-  XftFontClose(dpy, tf);
-  if (df)
-    XftFontClose(dpy, df);
-  XCloseDisplay(dpy);
+  /* never reached */
   return 0;
 }

--- a/util.c
+++ b/util.c
@@ -1,0 +1,37 @@
+/* See LICENSE file for copyright and license details. */
+#include <errno.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "util.h"
+
+void
+die(const char *fmt, ...)
+{
+	va_list ap;
+	int saved_errno;
+
+	saved_errno = errno;
+
+	va_start(ap, fmt);
+	vfprintf(stderr, fmt, ap);
+	va_end(ap);
+
+	if (fmt[0] && fmt[strlen(fmt)-1] == ':')
+		fprintf(stderr, " %s", strerror(saved_errno));
+	fputc('\n', stderr);
+
+	exit(1);
+}
+
+void *
+ecalloc(size_t nmemb, size_t size)
+{
+	void *p;
+
+	if (!(p = calloc(nmemb, size)))
+		die("calloc:");
+	return p;
+}

--- a/util.h
+++ b/util.h
@@ -1,0 +1,9 @@
+/* See LICENSE file for copyright and license details. */
+
+#define MAX(A, B)               ((A) > (B) ? (A) : (B))
+#define MIN(A, B)               ((A) < (B) ? (A) : (B))
+#define BETWEEN(X, A, B)        ((A) <= (X) && (X) <= (B))
+#define LENGTH(X)               (sizeof (X) / sizeof (X)[0])
+
+void die(const char *fmt, ...);
+void *ecalloc(size_t nmemb, size_t size);


### PR DESCRIPTION
Refactor drawing logic to reuse dwm's `drw`, bringing in a font fallback support.